### PR TITLE
Add quadruped control module

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -232,10 +232,12 @@ set(msg_files
 	VehicleRoi.msg
 	VehicleThrustSetpoint.msg
 	VehicleTorqueSetpoint.msg
-	VelocityLimits.msg
-	WheelEncoders.msg
-	Wind.msg
-	YawEstimatorStatus.msg
+        VelocityLimits.msg
+        WheelEncoders.msg
+        QuadrupedLegCommand.msg
+        QuadrupedLegStatus.msg
+        Wind.msg
+        YawEstimatorStatus.msg
 	versioned/ActuatorMotors.msg
 	versioned/ActuatorServos.msg
 	versioned/AirspeedValidated.msg

--- a/msg/QuadrupedLegCommand.msg
+++ b/msg/QuadrupedLegCommand.msg
@@ -1,0 +1,3 @@
+uint64 timestamp                        # time since system start (microseconds)
+float32[12] joint_position              # [rad]
+float32[12] joint_velocity              # [rad/s]

--- a/msg/QuadrupedLegStatus.msg
+++ b/msg/QuadrupedLegStatus.msg
@@ -1,0 +1,3 @@
+uint64 timestamp
+float32[12] joint_position              # [rad]
+float32[12] joint_velocity              # [rad/s]

--- a/src/modules/quadruped_control/CMakeLists.txt
+++ b/src/modules/quadruped_control/CMakeLists.txt
@@ -1,0 +1,44 @@
+############################################################################
+#
+#   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+        MODULE modules__quadruped_control
+        MAIN quadruped_control
+        SRCS
+                QuadrupedControl.cpp
+                QuadrupedControl.hpp
+        DEPENDS
+                px4_work_queue
+        MODULE_CONFIG
+                module.yaml
+)

--- a/src/modules/quadruped_control/Kconfig
+++ b/src/modules/quadruped_control/Kconfig
@@ -1,0 +1,5 @@
+menuconfig MODULES_QUADRUPED_CONTROL
+    bool "quadruped_control"
+    default n
+    ---help---
+        Enable quadruped control module

--- a/src/modules/quadruped_control/QuadrupedControl.cpp
+++ b/src/modules/quadruped_control/QuadrupedControl.cpp
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "QuadrupedControl.hpp"
+
+QuadrupedControl::QuadrupedControl() :
+        ModuleParams(nullptr),
+        ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl)
+{
+}
+
+bool QuadrupedControl::init()
+{
+        ScheduleOnInterval(10_ms);
+        return true;
+}
+
+void QuadrupedControl::updateParams()
+{
+        ModuleParams::updateParams();
+}
+
+void QuadrupedControl::Run()
+{
+        if (should_exit()) {
+                ScheduleClear();
+                exit_and_cleanup();
+                return;
+        }
+
+        if (_parameter_update_sub.updated()) {
+                parameter_update_s p{};
+                _parameter_update_sub.copy(&p);
+                updateParams();
+        }
+
+        quadruped_leg_command_s cmd{};
+
+        if (_leg_command_sub.update(&cmd)) {
+                quadruped_leg_status_s status{};
+                status.timestamp = hrt_absolute_time();
+                memcpy(status.joint_position, cmd.joint_position, sizeof(status.joint_position));
+                memcpy(status.joint_velocity, cmd.joint_velocity, sizeof(status.joint_velocity));
+                _leg_status_pub.publish(status);
+        }
+}
+
+int QuadrupedControl::task_spawn(int argc, char *argv[])
+{
+        QuadrupedControl *instance = new QuadrupedControl();
+
+        if (instance && instance->init()) {
+                _object.store(instance);
+                _task_id = task_id_is_work_queue; // task id for scheduled work item
+                return 0;
+        }
+
+        delete instance;
+        return -1;
+}
+
+int QuadrupedControl::custom_command(int argc, char *argv[])
+{
+        return print_usage("unknown command");
+}
+
+int QuadrupedControl::print_usage(const char *reason)
+{
+        if (reason) {
+                PX4_INFO("%s", reason);
+        }
+
+        PRINT_MODULE_DESCRIPTION(
+                R"DESCR(
+### Description
+Simple quadruped control module example. It republishes leg commands as status.
+)DESCR");
+
+        PRINT_MODULE_USAGE_NAME("quadruped_control", "controller");
+        return 0;
+}
+
+extern "C" __EXPORT int quadruped_control_main(int argc, char *argv[])
+{
+        return QuadrupedControl::main(argc, argv);
+}

--- a/src/modules/quadruped_control/QuadrupedControl.hpp
+++ b/src/modules/quadruped_control/QuadrupedControl.hpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+#include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/quadruped_leg_command.h>
+#include <uORB/topics/quadruped_leg_status.h>
+
+using namespace time_literals;
+
+class QuadrupedControl : public ModuleBase<QuadrupedControl>, public ModuleParams,
+        public px4::ScheduledWorkItem
+{
+public:
+        QuadrupedControl();
+        ~QuadrupedControl() override = default;
+
+        static int task_spawn(int argc, char *argv[]);
+        static int custom_command(int argc, char *argv[]);
+        static int print_usage(const char *reason = nullptr);
+
+        bool init();
+
+private:
+        void Run() override;
+        void updateParams() override;
+
+        uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
+        uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
+        uORB::Subscription _leg_command_sub{ORB_ID(quadruped_leg_command)};
+
+        uORB::Publication<quadruped_leg_status_s> _leg_status_pub{ORB_ID(quadruped_leg_status)};
+
+        DEFINE_PARAMETERS(
+                (ParamInt<px4::params::QD_MODE>) _param_qd_mode
+        )
+};

--- a/src/modules/quadruped_control/module.yaml
+++ b/src/modules/quadruped_control/module.yaml
@@ -1,0 +1,13 @@
+module_name: Quadruped Control
+
+parameters:
+  - group: Quadruped
+    definitions:
+      QD_MODE:
+        description:
+          short: Quadruped mode
+          long: 0: wheel mode, 1: leg mode
+        type: int32
+        min: 0
+        max: 1
+        default: 0

--- a/src/modules/quadruped_control/parameters.c
+++ b/src/modules/quadruped_control/parameters.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Quadruped mode
+ *
+ * 0: wheel mode, 1: leg mode
+ *
+ * @group Quadruped
+ */
+PARAM_DEFINE_INT32(QD_MODE, 0);
+


### PR DESCRIPTION
## Summary
- add uORB messages for quadruped joint commands and status
- register new messages in build
- implement a basic `quadruped_control` module
- provide module configuration and parameter definition

## Testing
- `make check_format` *(fails: astyle is not installed)*
- `make px4_sitl_default -j2` *(fails: kconfiglib missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fec2f3d90832abc27ec0c7c3c6748