### PR TITLE
Add quadruped Gazebo simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Joint position and velocity arrays contain 16 elements in the order
 Run `Tools/setup/ubuntu.sh` once to install the build and formatting dependencies required to
 compile the quadruped firmware and run `make check_format`.
 
+To test the quadruped in simulation run:
+
+```bash
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped
+```
+
+This launches Gazebo with the quadruped model and the wheel encoder plugin.
+
 
 ## Changing Code and Contributing
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4022_gz_quadruped
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4022_gz_quadruped
@@ -1,0 +1,59 @@
+#!/bin/sh
+# @name Simple Quadruped Robot
+# @type Rover
+# @class Rover
+
+. ${R}etc/init.d/rc.rover_differential_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=quadruped}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=quadruped}
+
+param set-default SIM_GZ_EN 1 # Gazebo bridge
+
+param set-default NAV_ACC_RAD 0.5
+
+# Differential Parameters
+param set-default RD_WHEEL_TRACK 0.3
+param set-default RD_MAX_THR_YAW_R 1.5
+param set-default RD_TRANS_DRV_TRN 0.349066
+param set-default RD_TRANS_TRN_DRV 0.174533
+
+# Rover Control Parameters
+param set-default RO_ACCEL_LIM 5
+param set-default RO_DECEL_LIM 10
+param set-default RO_JERK_LIM 30
+param set-default RO_MAX_THR_SPEED 2.1
+
+# Rover Rate Control Parameters
+param set-default RO_YAW_RATE_I 0.01
+param set-default RO_YAW_RATE_P 0.25
+param set-default RO_YAW_RATE_LIM 180
+param set-default RO_YAW_ACCEL_LIM 120
+param set-default RO_YAW_DECEL_LIM 1000
+
+# Rover Attitude Control Parameters
+param set-default RO_YAW_P 5
+
+# Rover Position Control Parameters
+param set-default RO_SPEED_LIM 2
+param set-default RO_SPEED_I 0.01
+param set-default RO_SPEED_P 0.1
+
+# Pure Pursuit parameters
+param set-default PP_LOOKAHD_GAIN 1
+param set-default PP_LOOKAHD_MAX 10
+param set-default PP_LOOKAHD_MIN 1
+
+# Actuator mapping
+param set-default SIM_GZ_WH_FUNC1 101 # right wheel
+param set-default SIM_GZ_WH_MIN1 70
+param set-default SIM_GZ_WH_MAX1 130
+param set-default SIM_GZ_WH_DIS1 100
+
+param set-default SIM_GZ_WH_FUNC2 102 # left wheel
+param set-default SIM_GZ_WH_MIN2 70
+param set-default SIM_GZ_WH_MAX2 130
+param set-default SIM_GZ_WH_DIS2 100
+
+param set-default SIM_GZ_WH_REV 1 # reverse right wheel

--- a/Tools/astyle/check_code_style_all.sh
+++ b/Tools/astyle/check_code_style_all.sh
@@ -45,7 +45,7 @@ fi
 
 # install git pre-commit hook
 HOOK_FILE="$DIR/../../.git/hooks/pre-commit"
-if [ ! -f $HOOK_FILE ] && [ "$CI" != "true" ] && [ $- == *i* ]; then
+if [ ! -f "$HOOK_FILE" ] && [ "$CI" != "true" ] && [[ $- == *i* ]]; then
 	echo ""
 	echo -e "\033[31mNinja tip: add a git pre-commit hook to automatically check code style\033[0m"
 	echo -e "Would you like to install one now? (\033[94mcp ./Tools/astyle/pre-commit .git/hooks/pre-commit\033[0m): [y/\033[1mN\033[0m]"

--- a/Tools/simulation/quadruped/models/quadruped/model.config
+++ b/Tools/simulation/quadruped/models/quadruped/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>quadruped</name>
+  <version>1.0</version>
+  <sdf version='1.5'>model.sdf</sdf>
+  <license>https://github.com/aionrobotics/aion_io/blob/master/LICENSE.txt</license>
+
+  <author>
+   <name>Nicholas Nunno</name>
+  </author>
+
+  <description>
+    Simple quadruped robot with wheels for use with the experimental quadruped_control module.
+  </description>
+</model>

--- a/Tools/simulation/quadruped/models/quadruped/model.sdf
+++ b/Tools/simulation/quadruped/models/quadruped/model.sdf
@@ -1,0 +1,598 @@
+<sdf version='1.6'>
+        <model name='quadruped'>
+	<link name='base_link'>
+			<pose>0 0 0 0 -0 0</pose>
+			<inertial>
+				<pose>0 0 0 0 -0 0</pose>
+				<mass>20.0</mass>
+				<inertia>
+					<ixx>0.37083</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.37083</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.53333</izz>
+				</inertia>
+			</inertial>
+			<collision name='odom_fixed_joint_lump__base_link_collision'>
+				<pose>0 0 0.15 0 -0 0</pose>
+				<geometry>
+					<box>
+					<size>0.4 0.4 0.25</size>
+					</box>
+				</geometry>
+				<surface>
+					<contact>
+						<ode/>
+					</contact>
+					<friction>
+						<ode/>
+					</friction>
+				</surface>
+			</collision>
+			<visual name='odom_fixed_joint_lump__base_link_visual'>
+				<pose>0 0 0 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/chassis_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>1.0 1.0 1.0</diffuse>
+					<specular>1.0 1.0 1.0</specular>
+				</material>
+			</visual>
+			<visual name='odom_fixed_joint_lump__top_link_visual_1'>
+				<pose>0 0 0.114486 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/top_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>1.0 1.0 1.0</diffuse>
+					<specular>1.0 1.0 1.0</specular>
+				</material>
+			</visual>
+			<visual name='odom_fixed_joint_lump__battery_link_visual_2'>
+				<pose>-0.09302 -0.000128 0.114486 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/battery_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<visual name='odom_fixed_joint_lump__housing_link_visual_3'>
+				<pose>0.03473 0 0.114486 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/housing_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<visual name='odom_fixed_joint_lump__l_antenna_link_visual_4'>
+				<pose>-0.1565 0.0762 0.114486 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/antenna_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<visual name='odom_fixed_joint_lump__r_antenna_link_visual_5'>
+				<pose>-0.1565 -0.0762 0.114486 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/antenna_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<velocity_decay/>
+			<velocity_decay/>
+			<velocity_decay/>
+			<velocity_decay/>
+			<velocity_decay/>
+			<gravity>1</gravity>
+			<velocity_decay/>
+			<sensor name="imu_sensor" type="imu">
+				<always_on>1</always_on>
+				<update_rate>250</update_rate>
+				<imu>
+					<angular_velocity>
+						<x>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.0003394</stddev>
+							<dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+						</noise>
+						</x>
+						<y>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.0003394</stddev>
+							<dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+						</noise>
+						</y>
+						<z>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.0003394</stddev>
+							<dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+						</noise>
+						</z>
+					</angular_velocity>
+					<linear_acceleration>
+						<x>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.004</stddev>
+							<dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+						</noise>
+						</x>
+						<y>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.004</stddev>
+							<dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+						</noise>
+						</y>
+						<z>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.004</stddev>
+							<dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+							<dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+						</noise>
+						</z>
+					</linear_acceleration>
+				</imu>
+			</sensor>
+			<sensor name="air_pressure_sensor" type="air_pressure">
+				<always_on>1</always_on>
+				<update_rate>50</update_rate>
+				<air_pressure>
+					<pressure>
+						<noise type="gaussian">
+							<mean>0</mean>
+							<stddev>0.01</stddev>
+						</noise>
+					</pressure>
+				</air_pressure>
+			</sensor>
+			<sensor name="magnetometer_sensor" type="magnetometer">
+				<always_on>1</always_on>
+				<update_rate>100</update_rate>
+				<magnetometer>
+				<!-- TODO: update to fix units and coordinate system when we move past Harmonic -->
+				<!-- See https://github.com/gazebosim/gz-sim/pull/2460 -->
+				<!-- 3mgauss RMS: NOTE: noise is in tesla but sensor reports data in gauss -->
+				<!-- Noise modeled after IIS2MDC -->
+					<x>
+						<noise type="gaussian">
+						<stddev>0.0001</stddev>
+						</noise>
+					</x>
+					<y>
+						<noise type="gaussian">
+						<stddev>0.0001</stddev>
+						</noise>
+					</y>
+					<z>
+						<noise type="gaussian">
+						<stddev>0.0001</stddev>
+						</noise>
+					</z>
+				</magnetometer>
+			</sensor>
+			<sensor name="navsat_sensor" type="navsat">
+				<always_on>1</always_on>
+				<update_rate>30</update_rate>
+			</sensor>
+		</link>
+		<link name='lf_wheel_link'>
+			<pose>0.15 0.16317 0.0215 0 -0 0</pose>
+			<inertial>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<mass>0.414</mass>
+				<inertia>
+					<ixx>0.00068682</ixx>
+					<ixy>0</ixy>
+					<ixz>0</ixz>
+					<iyy>0.00068682</iyy>
+					<iyz>0</iyz>
+					<izz>0.00097299</izz>
+				</inertia>
+			</inertial>
+			<collision name='lf_wheel_link_collision'>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<geometry>
+					<cylinder>
+						<radius>0.0686</radius>
+						<length>0.0762</length>
+					</cylinder>
+				</geometry>
+				<max_contacts>1</max_contacts>
+				<surface>
+					<friction>
+						<torsional>
+							<coefficient>0.25</coefficient>
+							<use_patch_radius>1</use_patch_radius>
+							<surface_radius>0.0686</surface_radius>
+						</torsional>
+						<ode>
+							<mu>1.0</mu>
+							<mu2>1.0</mu2>
+							<fdir1>1 0 0</fdir1>
+							<slip1>0.0</slip1>
+							<slip2>0.0</slip2>
+						</ode>
+					</friction>
+					<bounce>
+						<restitution_coefficient>0</restitution_coefficient>
+						<threshold>1e6</threshold>
+					</bounce>
+					<contact>
+						<ode>
+							<min_depth>0.001</min_depth>
+							<max_vel>0.0</max_vel>
+							<kp>1.0e6</kp>
+							<kd>100.0</kd>
+						</ode>
+					</contact>
+				</surface>
+			</collision>
+			<visual name='lf_wheel_link_visual'>
+				<pose>0 0 0 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/wheel_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<gravity>1</gravity>
+			<velocity_decay/>
+		</link>
+		<joint name='motor_0' type='revolute'>
+			<child>lf_wheel_link</child>
+			<parent>base_link</parent>
+			<axis>
+				<xyz>0 1 0</xyz>
+				<limit>
+					<lower>-1e+16</lower>
+					<upper>1e+16</upper>
+				</limit>
+				<dynamics>
+					<spring_reference>0</spring_reference>
+					<spring_stiffness>0</spring_stiffness>
+				</dynamics>
+				<use_parent_model_frame>1</use_parent_model_frame>
+			</axis>
+		</joint>
+		<link name='lb_wheel_link'>
+			<pose>-0.15 0.16317 0.0215 0 -0 0</pose>
+			<inertial>
+			<pose>0 0 0 1.57079632679 0 0</pose>
+			<mass>0.414</mass>
+				<inertia>
+					<ixx>0.00068682</ixx>
+					<ixy>0</ixy>
+					<ixz>0</ixz>
+					<iyy>0.00068682</iyy>
+					<iyz>0</iyz>
+					<izz>0.00097299</izz>
+				</inertia>
+			</inertial>
+			<collision name='lb_wheel_link_collision'>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<geometry>
+					<cylinder>
+						<radius>0.0686</radius>
+						<length>0.0762</length>
+					</cylinder>
+				</geometry>
+				<max_contacts>1</max_contacts>
+				<surface>
+					<friction>
+					<torsional>
+						<coefficient>0.25</coefficient>
+						<use_patch_radius>1</use_patch_radius>
+						<surface_radius>0.0686</surface_radius>
+					</torsional>
+					<ode>
+						<mu>1.0</mu>
+						<mu2>1.0</mu2>
+						<fdir1>1 0 0</fdir1>
+						<slip1>0.0</slip1>
+						<slip2>0.0</slip2>
+					</ode>
+					</friction>
+					<bounce>
+						<restitution_coefficient>0</restitution_coefficient>
+						<threshold>1e6</threshold>
+					</bounce>
+					<contact>
+					<ode>
+						<min_depth>0.001</min_depth>
+						<max_vel>0.0</max_vel>
+						<kp>1.0e6</kp>
+						<kd>100.0</kd>
+					</ode>
+					</contact>
+				</surface>
+			</collision>
+			<visual name='lb_wheel_link_visual'>
+				<pose>0 0 0 0 -0 0</pose>
+					<geometry>
+						<mesh>
+							<scale>1 1 1</scale>
+							<uri>model://r1_rover/meshes/wheel_link.STL</uri>
+						</mesh>
+					</geometry>
+					<material>
+						<diffuse>0.0 0.0 0.0</diffuse>
+						<specular>0.5 0.5 0.5</specular>
+					</material>
+			</visual>
+			<gravity>1</gravity>
+			<velocity_decay/>
+		</link>
+		<joint name='motor_1' type='revolute'>
+			<child>lb_wheel_link</child>
+			<parent>base_link</parent>
+			<axis>
+				<xyz>0 1 0</xyz>
+				<limit>
+					<lower>-1e+16</lower>
+					<upper>1e+16</upper>
+				</limit>
+				<dynamics>
+					<spring_reference>0</spring_reference>
+					<spring_stiffness>0</spring_stiffness>
+				</dynamics>
+				<use_parent_model_frame>1</use_parent_model_frame>
+			</axis>
+		</joint>
+		<link name='rf_wheel_link'>
+			<pose>0.15 -0.16317 0.0215 0 -0 0</pose>
+			<inertial>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<mass>0.414</mass>
+				<inertia>
+					<ixx>0.00068682</ixx>
+					<ixy>0</ixy>
+					<ixz>0</ixz>
+					<iyy>0.00068682</iyy>
+					<iyz>0</iyz>
+					<izz>0.00097299</izz>
+				</inertia>
+			</inertial>
+			<collision name='rf_wheel_link_collision'>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<geometry>
+					<cylinder>
+						<radius>0.0686</radius>
+						<length>0.0762</length>
+					</cylinder>
+				</geometry>
+				<max_contacts>1</max_contacts>
+				<surface>
+					<friction>
+					<torsional>
+					<coefficient>0.25</coefficient>
+					<use_patch_radius>1</use_patch_radius>
+					<surface_radius>0.0686</surface_radius>
+					</torsional>
+					<ode>
+					<mu>1.0</mu>
+					<mu2>1.0</mu2>
+					<fdir1>1 0 0</fdir1>
+					<slip1>0.0</slip1>
+					<slip2>0.0</slip2>
+					</ode>
+					</friction>
+					<bounce>
+					<restitution_coefficient>0</restitution_coefficient>
+					<threshold>1e6</threshold>
+					</bounce>
+					<contact>
+					<ode>
+					<min_depth>0.001</min_depth>
+					<max_vel>0.0</max_vel>
+					<kp>1.0e6</kp>
+					<kd>100.0</kd>
+					</ode>
+					</contact>
+				</surface>
+			</collision>
+			<visual name='rf_wheel_link_visual'>
+				<pose>0 0 0 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/wheel_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<gravity>1</gravity>
+			<velocity_decay/>
+		</link>
+		<joint name='motor_2' type='revolute'>
+			<child>rf_wheel_link</child>
+			<parent>base_link</parent>
+			<axis>
+				<xyz>0 -1 0</xyz>
+				<limit>
+					<lower>-1e+16</lower>
+					<upper>1e+16</upper>
+				</limit>
+				<dynamics>
+					<spring_reference>0</spring_reference>
+					<spring_stiffness>0</spring_stiffness>
+				</dynamics>
+				<use_parent_model_frame>1</use_parent_model_frame>
+			</axis>
+		</joint>
+		<link name='rb_wheel_link'>
+			<pose>-0.15 -0.16317 0.0215 0 -0 0</pose>
+			<inertial>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<mass>0.414</mass>
+				<inertia>
+					<ixx>0.00068682</ixx>
+					<ixy>0</ixy>
+					<ixz>0</ixz>
+					<iyy>0.00068682</iyy>
+					<iyz>0</iyz>
+					<izz>0.00097299</izz>
+				</inertia>
+			</inertial>
+			<collision name='rb_wheel_link_collision'>
+				<pose>0 0 0 1.57079632679 0 0</pose>
+				<geometry>
+					<cylinder>
+						<radius>0.0686</radius>
+						<length>0.0762</length>
+					</cylinder>
+				</geometry>
+				<max_contacts>1</max_contacts>
+				<surface>
+					<friction>
+						<torsional>
+							<coefficient>0.25</coefficient>
+							<use_patch_radius>1</use_patch_radius>
+							<surface_radius>0.0686</surface_radius>
+						</torsional>
+						<ode>
+							<mu>1.0</mu>
+							<mu2>1.0</mu2>
+							<fdir1>1 0 0</fdir1>
+							<slip1>0.0</slip1>
+							<slip2>0.0</slip2>
+						</ode>
+					</friction>
+					<bounce>
+						<restitution_coefficient>0</restitution_coefficient>
+						<threshold>1e6</threshold>
+					</bounce>
+					<contact>
+						<ode>
+							<min_depth>0.001</min_depth>
+							<kp>1e8</kp>
+						</ode>
+					</contact>
+				</surface>
+			</collision>
+			<visual name='rb_wheel_link_visual'>
+				<pose>0 0 0 0 -0 0</pose>
+				<geometry>
+					<mesh>
+						<scale>1 1 1</scale>
+						<uri>model://r1_rover/meshes/wheel_link.STL</uri>
+					</mesh>
+				</geometry>
+				<material>
+					<diffuse>0.0 0.0 0.0</diffuse>
+					<specular>0.5 0.5 0.5</specular>
+				</material>
+			</visual>
+			<gravity>1</gravity>
+			<velocity_decay/>
+		</link>
+		<joint name='motor_3' type='revolute'>
+			<child>rb_wheel_link</child>
+			<parent>base_link</parent>
+			<axis>
+				<xyz>0 -1 0</xyz>
+				<limit>
+					<lower>-1e+16</lower>
+					<upper>1e+16</upper>
+				</limit>
+				<dynamics>
+					<spring_reference>0</spring_reference>
+					<spring_stiffness>0</spring_stiffness>
+				</dynamics>
+				<use_parent_model_frame>1</use_parent_model_frame>
+			</axis>
+		</joint>
+		<static>0</static>
+		<plugin filename="gz-sim-joint-controller-system" name="gz::sim::systems::JointController">
+			<joint_name>motor_0</joint_name>
+			<sub_topic>command/motor_speed</sub_topic>
+			<use_actuator_msg>true</use_actuator_msg>
+			<actuator_number>1</actuator_number>
+			<p_gain>10.0</p_gain>
+		</plugin>
+		<plugin filename="gz-sim-joint-controller-system" name="gz::sim::systems::JointController">
+			<joint_name>motor_1</joint_name>
+			<sub_topic>command/motor_speed</sub_topic>
+			<use_actuator_msg>true</use_actuator_msg>
+			<actuator_number>1</actuator_number>
+			<p_gain>10.0</p_gain>
+		</plugin>
+		<plugin filename="gz-sim-joint-controller-system" name="gz::sim::systems::JointController">
+			<joint_name>motor_2</joint_name>
+			<sub_topic>command/motor_speed</sub_topic>
+			<use_actuator_msg>true</use_actuator_msg>
+			<actuator_number>0</actuator_number>
+			<p_gain>10.0</p_gain>
+		</plugin>
+		<plugin filename="gz-sim-joint-controller-system" name="gz::sim::systems::JointController">
+			<joint_name>motor_3</joint_name>
+			<sub_topic>command/motor_speed</sub_topic>
+			<use_actuator_msg>true</use_actuator_msg>
+			<actuator_number>0</actuator_number>
+			<p_gain>10.0</p_gain>
+		</plugin>
+        <plugin
+            filename="gz-sim-joint-state-publisher-system"
+            name="gz::sim::systems::JointStatePublisher">
+            <joint_name>motor_0</joint_name>
+            <joint_name>motor_1</joint_name>
+            <joint_name>motor_2</joint_name>
+            <joint_name>motor_3</joint_name>
+        </plugin>
+        <plugin
+            filename="libWheelEncoderSystem.so"
+            name="custom::WheelEncoderSystem">
+            <joint>motor_0</joint>
+            <joint>motor_1</joint>
+            <joint>motor_2</joint>
+            <joint>motor_3</joint>
+        </plugin>
+        </model>
+</sdf>

--- a/Tools/simulation/quadruped/worlds/quadruped.sdf
+++ b/Tools/simulation/quadruped/worlds/quadruped.sdf
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version="1.9">
+  <world name="rover">
+    <physics type="ode">
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+    <scene>
+      <grid>true</grid>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <bounce/>
+            <contact>
+              <collide_bitmask>65535</collide_bitmask>
+              <ode>
+                <min_depth>0.005</min_depth>
+                <kp>1e8</kp>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <cast_shadows>false</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>400 400</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <include>
+      <uri>model://quadruped</uri>
+    </include>
+    <light name="sunUTC" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>47.397971057728974</latitude_deg>
+      <longitude_deg> 8.546163739800146</longitude_deg>
+      <elevation>0</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>

--- a/docs/en/frames_rover/quadruped.md
+++ b/docs/en/frames_rover/quadruped.md
@@ -60,3 +60,23 @@ After boot, the `quadruped_control` module starts automatically.
 * `QD_GAIT_AMP`  - leg rotation amplitude in radians for the gait generator.
 
 In leg mode the module runs a simple trot gait based on these parameters and publishes joint states.
+
+## Simulation
+
+The repository provides a basic Gazebo simulation model and world for testing
+the quadruped control module. Make sure the `Tools/simulation/gz` submodule is
+initialized:
+
+```bash
+git submodule update --init Tools/simulation/gz
+```
+
+Run the simulation with:
+
+```bash
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped
+```
+
+This launches Gazebo with the `quadruped` world and model, including the
+`WheelEncoderSystem` plugin that publishes wheel encoder data for the rover
+controllers.

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -11,8 +11,8 @@
 # https://gazebosim.org/api/sim/8/server_config.html
 # -----------------------------------------------------------------------
 
-export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models
-export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds
+export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models:@PX4_SOURCE_DIR@/Tools/simulation/quadruped/models
+export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds:@PX4_SOURCE_DIR@/Tools/simulation/quadruped/worlds
 export PX4_GZ_PLUGINS=@PX4_BINARY_DIR@/src/modules/simulation/gz_plugins
 export PX4_GZ_SERVER_CONFIG=@PX4_SOURCE_DIR@/src/modules/simulation/gz_bridge/server.config
 


### PR DESCRIPTION
## Summary
- create quadruped Gazebo model and world
- hook new paths into `gz_env.sh`
- document how to launch the simulation
- provide airframe config for the quadruped
- **remove binary mesh files**
- fix `check_format` script's interactive prompt

## Testing
- `make check_format`


------
https://chatgpt.com/codex/tasks/task_e_68424db245c8832aab7b892987a7f300