### PR TITLE
Add quadruped simulation instructions

### DIFF
--- a/Tools/simulation/quadruped/README.md
+++ b/Tools/simulation/quadruped/README.md
@@ -1,0 +1,20 @@
+# Quadruped Simulation
+
+This directory contains resources for simulating a simple quadruped robot using Gazebo Harmonic.
+
+```
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped
+```
+
+Ensure that the Gazebo models submodule is initialized and that the `gz-harmonic` package is installed.
+If the submodule becomes detached after running `make distclean`, reinitialize it recursively:
+
+```
+git submodule update --init Tools/simulation/gz
+git submodule update --init --recursive
+export GZ_DISTRO=harmonic
+```
+
+The `model` and `world` files included here provide a minimal environment with a ground plane, sun light source, and the quadruped model using the `WheelEncoderSystem` plugin.
+
+See [docs/en/frames_rover/quadruped.md](../../../docs/en/frames_rover/quadruped.md) for full details about the quadruped control module and hardware integration.

--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -231,7 +231,7 @@ void GZGimbal::publishJointCommand(gz::transport::Node::Publisher &publisher, co
 	float new_stp = computeJointSetpoint(att_stp, rate_stp, last_stp, dt);
 	new_stp = math::constrain(new_stp, min_stp, max_stp);
 	last_stp = new_stp;
-	msg.set_data(new_stp);
+    msg.set_data(static_cast<double>(new_stp));
 
 	publisher.Publish(msg);
 }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -115,8 +115,8 @@ bool GZMixingInterfaceServo::init(const std::string &model_name)
 			return false;
 		}
 
-		double min_val = get_servo_angle_min(i);
-		double max_val = get_servo_angle_max(i);
+               double min_val = static_cast<double>(get_servo_angle_min(i));
+               double max_val = static_cast<double>(get_servo_angle_max(i));
 		_angle_min_rad.push_back(min_val);
 		_angular_range_rad.push_back(max_val - min_val);
 	}


### PR DESCRIPTION
## Summary
- document Gazebo-based quadruped simulator
- clarify how to reinitialize Gazebo submodule
- fix double-promotion compile errors in GZ bridge modules

## Testing
- `bash Tools/setup/ubuntu.sh --no-nuttx --no-sim-tools`
- `make px4_sitl_default`


------
https://chatgpt.com/codex/tasks/task_e_68438d77efac832a98dfb7290bf93503