### PR TITLE
Fix quadruped docs and rebuild instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ simulation dependencies are missing, reinitialize the submodule and ensure the
 ```bash
 git submodule update --init --recursive
 brew install gz-harmonic  # macOS
+# or run Tools/setup/macos.sh --sim-tools
+# Ubuntu
+sudo apt-get update && sudo apt-get install gz-harmonic libunwind-dev libgz-msgs10-dev libgz-transport13-dev libgz-math7-dev libgz-utils2-dev
 # or run Tools/setup/ubuntu.sh on Linux
 ```
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4023_gz_quadruped_gait
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4023_gz_quadruped_gait
@@ -1,0 +1,62 @@
+#!/bin/sh
+# @name Simple Quadruped Robot
+# @type Rover
+# @class Rover
+
+. ${R}etc/init.d/rc.rover_differential_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=quadruped}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=quadruped}
+
+param set-default SIM_GZ_EN 1 # Gazebo bridge
+
+param set-default NAV_ACC_RAD 0.5
+
+# Differential Parameters
+param set-default RD_WHEEL_TRACK 0.3
+param set-default RD_MAX_THR_YAW_R 1.5
+param set-default RD_TRANS_DRV_TRN 0.349066
+param set-default RD_TRANS_TRN_DRV 0.174533
+
+# Rover Control Parameters
+param set-default RO_ACCEL_LIM 5
+param set-default RO_DECEL_LIM 10
+param set-default RO_JERK_LIM 30
+param set-default RO_MAX_THR_SPEED 2.1
+
+# Rover Rate Control Parameters
+param set-default RO_YAW_RATE_I 0.01
+param set-default RO_YAW_RATE_P 0.25
+param set-default RO_YAW_RATE_LIM 180
+param set-default RO_YAW_ACCEL_LIM 120
+param set-default RO_YAW_DECEL_LIM 1000
+
+# Rover Attitude Control Parameters
+param set-default RO_YAW_P 5
+
+# Rover Position Control Parameters
+param set-default RO_SPEED_LIM 2
+param set-default RO_SPEED_I 0.01
+param set-default RO_SPEED_P 0.1
+
+# Pure Pursuit parameters
+param set-default PP_LOOKAHD_GAIN 1
+param set-default PP_LOOKAHD_MAX 10
+param set-default PP_LOOKAHD_MIN 1
+
+# Actuator mapping
+param set-default SIM_GZ_WH_FUNC1 101 # right wheel
+param set-default SIM_GZ_WH_MIN1 70
+param set-default SIM_GZ_WH_MAX1 130
+param set-default SIM_GZ_WH_DIS1 100
+
+param set-default SIM_GZ_WH_FUNC2 102 # left wheel
+param set-default SIM_GZ_WH_MIN2 70
+param set-default SIM_GZ_WH_MAX2 130
+param set-default SIM_GZ_WH_DIS2 100
+
+param set-default SIM_GZ_WH_REV 1 # reverse right wheel
+param set-default QD_MODE 1 # enable gait mode
+param set-default QD_GAIT_FREQ 1.0
+param set-default QD_GAIT_AMP 0.4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -93,6 +93,7 @@ px4_add_romfs_files(
         4020_gz_tiltrotor
         4021_gz_x500_flow
         4022_gz_quadruped
+        4023_gz_quadruped_gait
 
         6011_gazebo-classic_typhoon_h480
         6011_gazebo-classic_typhoon_h480.post

--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -55,11 +55,17 @@ python3 -m pip install --user -r ${DIR}/requirements.txt
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
-	if brew ls --versions px4-sim > /dev/null; then
-		brew install px4-sim
-	elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
-		brew reinstall px4-sim
-	fi
+       if ! brew ls --versions px4-sim > /dev/null; then
+               brew install px4-sim
+       elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
+               brew reinstall px4-sim
+       fi
+
+       if ! brew ls --versions gz-harmonic > /dev/null; then
+               brew install gz-harmonic
+       elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
+               brew reinstall gz-harmonic
+       fi
 fi
 
 echo "All set! PX4 toolchain installed!"

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -208,7 +208,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		sudo apt-get update -y --quiet
 
 		# Install Gazebo
-		gazebo_packages="gz-harmonic libunwind-dev"
+                gazebo_packages="gz-harmonic libunwind-dev libgz-msgs10-dev libgz-transport13-dev libgz-math7-dev libgz-utils2-dev"
 
 		if [[ "${UBUNTU_RELEASE}" == "24.04" ]]; then
 			gazebo_packages="$gazebo_packages cppzmq-dev"

--- a/Tools/simulation/quadruped/README.md
+++ b/Tools/simulation/quadruped/README.md
@@ -1,0 +1,42 @@
+# Quadruped Simulation
+
+This directory contains resources for simulating a simple quadruped robot using Gazebo Harmonic.
+
+```
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped
+```
+
+To run the built-in gait generator start the gait target which enables leg mode
+and publishes a simple trot pattern:
+
+```
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped_gait
+```
+
+Ensure that the Gazebo models submodule is initialized and that the `gz-harmonic` package is installed.
+On macOS install the package with Homebrew:
+
+```bash
+brew install gz-harmonic
+./Tools/setup/macos.sh --sim-tools  # optional helper
+```
+
+On Ubuntu install the dependencies with:
+
+```bash
+sudo apt-get update && sudo apt-get install gz-harmonic libunwind-dev libgz-msgs10-dev libgz-transport13-dev libgz-math7-dev libgz-utils2-dev
+```
+If the submodule becomes detached after running `make distclean`, reinitialize it recursively:
+
+```
+git submodule update --init Tools/simulation/gz
+git submodule update --init --recursive
+export GZ_DISTRO=harmonic
+```
+
+If the build fails with `px4_gz_plugins` missing, run the above commands to
+ensure the models and plugins are downloaded.
+
+The `model` and `world` files included here provide a minimal environment with a ground plane, sun light source, and the quadruped model using the `WheelEncoderSystem` plugin.
+
+See [docs/en/frames_rover/quadruped.md](../../../docs/en/frames_rover/quadruped.md) for full details about the quadruped control module and hardware integration.

--- a/docs/en/frames_rover/quadruped.md
+++ b/docs/en/frames_rover/quadruped.md
@@ -68,10 +68,11 @@ the quadruped control module. Make sure the `Tools/simulation/gz` submodule is
 initialized and that Gazebo Harmonic is installed (the `Tools/setup/ubuntu.sh`
 script will install the required `gz-harmonic` package):
 
-On macOS the package can be installed using Homebrew:
+On macOS the package can be installed using Homebrew or via the setup script:
 
 ```bash
 brew install gz-harmonic
+./Tools/setup/macos.sh --sim-tools
 ```
 
 ```bash
@@ -98,9 +99,27 @@ missing, update the submodule and (re)install the `gz-harmonic` packages:
 ```bash
 git submodule update --init --recursive
 brew install gz-harmonic  # macOS
+# Ubuntu
+sudo apt-get update && sudo apt-get install gz-harmonic libunwind-dev
+# Ubuntu dependencies
+sudo apt-get install libgz-msgs10-dev libgz-transport13-dev libgz-math7-dev libgz-utils2-dev
 # or run Tools/setup/ubuntu.sh on Linux
 ```
+
+If you instead see an error that `px4_gz_plugins` is missing, the Gazebo models
+submodule was not initialized correctly. Run the same commands above to clone it
+again.
 
 This launches Gazebo with the `quadruped` world and model, including the
 `WheelEncoderSystem` plugin that publishes wheel encoder data for the rover
 controllers.
+
+To watch the quadruped walk using the internal gait generator, run the gait
+demo target instead:
+
+```bash
+PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped_gait
+```
+
+The gait demo loads an airframe configuration that sets `QD_MODE` to `1` and
+uses the default gait frequency and amplitude.

--- a/docs/en/sim_gazebo_gz/vehicles.md
+++ b/docs/en/sim_gazebo_gz/vehicles.md
@@ -199,3 +199,28 @@ make px4_sitl gz_rover_ackermann
 ```
 
 ![Ackermann Rover in Gazebo](../../assets/simulation/gazebo/vehicles/rover_ackermann.png)
+
+### Quadruped Rover
+
+The quadruped robot can be driven like a rover or walked using the experimental
+`quadruped_control` module.
+
+```sh
+make px4_sitl gz_quadruped
+```
+
+If CMake reports that Gazebo dependencies are missing, initialize the models submodule
+and install `gz-harmonic`:
+
+```bash
+git submodule update --init --recursive
+brew install gz-harmonic  # macOS
+./Tools/setup/macos.sh --sim-tools
+sudo apt-get update && sudo apt-get install gz-harmonic libunwind-dev libgz-msgs10-dev libgz-transport13-dev libgz-math7-dev libgz-utils2-dev  # Ubuntu
+```
+
+Run the gait demo to see the quadruped walking:
+
+```sh
+make px4_sitl gz_quadruped_gait
+```

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -37,7 +37,10 @@ else()
     find_package(gz-transport NAMES gz-transport13)
 endif()
 
-file(GLOB gz_worlds ${PX4_SOURCE_DIR}/Tools/simulation/gz/worlds/*.sdf)
+file(GLOB gz_worlds
+    ${PX4_SOURCE_DIR}/Tools/simulation/gz/worlds/*.sdf
+    ${PX4_SOURCE_DIR}/Tools/simulation/quadruped/worlds/*.sdf
+)
 file(GLOB gz_airframes ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/init.d-posix/airframes/*_gz_*)
 
 if (gz-transport_FOUND)
@@ -89,9 +92,9 @@ if (gz-transport_FOUND)
 	# Below we setup the build targets for our worlds and models
 	# Syntax: gz_<model_name>_<world_name>
 	# Example: gz_x500_flow_forest
-	foreach(gz_airframe IN LISTS gz_airframes)
-		set(model_name)
-		string(REGEX REPLACE ".*_gz_" "" model_name ${gz_airframe})
+        foreach(gz_airframe IN LISTS gz_airframes)
+                set(model_name)
+                string(REGEX REPLACE ".*_gz_" "" model_name ${gz_airframe})
 
 		foreach(world ${gz_worlds})
 			get_filename_component("world_name" ${world} NAME_WE)
@@ -115,7 +118,20 @@ if (gz-transport_FOUND)
 	endforeach()
 
 	# Setup the environment variables: PX4_GZ_MODELS, PX4_GZ_WORLDS, GZ_SIM_RESOURCE_PATH
-	configure_file(gz_env.sh.in ${PX4_BINARY_DIR}/rootfs/gz_env.sh)
+        configure_file(gz_env.sh.in ${PX4_BINARY_DIR}/rootfs/gz_env.sh)
+
+        # Provide alias targets for the quadruped world. Skip if the default
+        # world already created targets with these names.
+        if(TARGET gz_quadruped_quadruped)
+                if(NOT TARGET gz_quadruped)
+                        add_custom_target(gz_quadruped DEPENDS gz_quadruped_quadruped)
+                endif()
+        endif()
+        if(TARGET gz_quadruped_gait_quadruped)
+                if(NOT TARGET gz_quadruped_gait)
+                        add_custom_target(gz_quadruped_gait DEPENDS gz_quadruped_gait_quadruped)
+                endif()
+        endif()
 
 else()
 	# Create fallback targets that provide helpful error messages when Gazebo dependencies are missing
@@ -143,8 +159,17 @@ else()
                                         VERBATIM
                                 )
 			endif()
-		endforeach()
-	endforeach()
+                endforeach()
+        endforeach()
 
-	message(STATUS "Gazebo simulation bridge module disabled: missing dependencies")
+        # Provide alias targets for the quadruped world when dependencies are
+        # missing so that 'gz_quadruped' and 'gz_quadruped_gait' always exist
+        if(TARGET gz_quadruped_quadruped AND NOT TARGET gz_quadruped)
+                add_custom_target(gz_quadruped DEPENDS gz_quadruped_quadruped)
+        endif()
+        if(TARGET gz_quadruped_gait_quadruped AND NOT TARGET gz_quadruped_gait)
+                add_custom_target(gz_quadruped_gait DEPENDS gz_quadruped_gait_quadruped)
+        endif()
+
+        message(STATUS "Gazebo simulation bridge module disabled: missing dependencies")
 endif()

--- a/src/modules/simulation/gz_bridge/GZGimbal.cpp
+++ b/src/modules/simulation/gz_bridge/GZGimbal.cpp
@@ -231,7 +231,7 @@ void GZGimbal::publishJointCommand(gz::transport::Node::Publisher &publisher, co
 	float new_stp = computeJointSetpoint(att_stp, rate_stp, last_stp, dt);
 	new_stp = math::constrain(new_stp, min_stp, max_stp);
 	last_stp = new_stp;
-	msg.set_data(new_stp);
+    msg.set_data(static_cast<double>(new_stp));
 
 	publisher.Publish(msg);
 }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -115,8 +115,8 @@ bool GZMixingInterfaceServo::init(const std::string &model_name)
 			return false;
 		}
 
-		double min_val = get_servo_angle_min(i);
-		double max_val = get_servo_angle_max(i);
+               double min_val = static_cast<double>(get_servo_angle_min(i));
+               double max_val = static_cast<double>(get_servo_angle_max(i));
 		_angle_min_rad.push_back(min_val);
 		_angular_range_rad.push_back(max_val - min_val);
 	}


### PR DESCRIPTION
## Summary
- prevent floating-point warnings in Gazebo bridge code
- document optional macOS setup command for Gazebo packages
- provide Gazebo simulation targets when dependencies are missing

## Testing
- `bash Tools/setup/ubuntu.sh --no-nuttx --no-sim-tools`
- `make px4_sitl_default`
- `PX4_GZ_WORLD=quadruped make px4_sitl gz_quadruped` *(fails: Gazebo simulation dependencies not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438d77efac832a98dfb7290bf93503