### PR TITLE
Add basic quadruped gait parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Release notes and supporting information for PX4 releases can be found on the [D
 
 The [PX4 User Guide](https://docs.px4.io/main/en/) explains how to assemble [supported vehicles](https://docs.px4.io/main/en/airframes/airframe_reference.html) and fly drones with PX4. See the [forum and chat](https://docs.px4.io/main/en/#getting-help) if you need help!
 
+To build the codebase or run checks you need the required dependencies. Run `Tools/setup/ubuntu.sh` (or install the Python packages manually, e.g. `pip3 install kconfiglib`) before executing `make check`.
+
 
 ## Changing Code and Contributing
 

--- a/src/modules/quadruped/Quadruped.cpp
+++ b/src/modules/quadruped/Quadruped.cpp
@@ -2,7 +2,11 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/parameter_update.h>
 #include <uORB/topics/quadruped_leg_command.h>
+#include <mathlib/mathlib.h>
+#include <cmath>
 
 using namespace time_literals;
 
@@ -11,6 +15,7 @@ class Quadruped : public ModuleBase<Quadruped>, public ModuleParams, public px4:
 public:
 	Quadruped() : ModuleParams(nullptr), ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers)
 	{
+		_start_time = hrt_absolute_time();
 	}
 
 	~Quadruped() override { }
@@ -29,14 +34,43 @@ public:
 			return;
 		}
 
+		if (_parameter_update_sub.updated()) {
+			parameter_update_s p{};
+			_parameter_update_sub.copy(&p);
+			updateParams();
+		}
+
+		const float period_s = math::max(0.001f, static_cast<float>(_param_qdp_period_ms.get()) / 1000.f);
+		const float amp = math::constrain(_param_qdp_step_amp.get(), 0.f, 1.f);
+		const float rot_amp = math::constrain(_param_qdp_rotate_amp.get(), 0.f, 1.f);
+
+		const float phase = fmodf((hrt_absolute_time() - _start_time) / 1e6f, period_s) / period_s;
+
 		quadruped_leg_command_s cmd{};
 		cmd.timestamp = hrt_absolute_time();
-		// currently send zeros
+
+		for (int i = 0; i < 4; ++i) {
+			float leg_phase = phase + ((i == 1 || i == 2) ? 0.5f : 0.f);
+
+			if (leg_phase >= 1.f) { leg_phase -= 1.f; }
+
+			cmd.wheel_setpoints[i] = (leg_phase < 0.5f) ? amp : -amp;
+			cmd.rotate_setpoints[i] = rot_amp * sinf(leg_phase * M_PI_F * 2.f);
+		}
+
 		_cmd_pub.publish(cmd);
 	}
 
 private:
 	uORB::Publication<quadruped_leg_command_s> _cmd_pub{ORB_ID(quadruped_leg_command)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
+	hrt_abstime _start_time{0};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::QDP_PERIOD_MS>) _param_qdp_period_ms,
+		(ParamFloat<px4::params::QDP_STEP_AMP>) _param_qdp_step_amp,
+		(ParamFloat<px4::params::QDP_ROTATE_AMP>) _param_qdp_rotate_amp
+	)
 };
 
 int Quadruped_main(int argc, char *argv[])

--- a/src/modules/quadruped/module.yaml
+++ b/src/modules/quadruped/module.yaml
@@ -1,4 +1,29 @@
 module_name: quadruped
 keywords: [quadruped]
 module_description: "Basic quadruped control module based on rover functionality"
-parameters: []
+parameters:
+    - group: Quadruped
+      definitions:
+        QDP_PERIOD_MS:
+            description:
+                short: Gait cycle period in milliseconds
+            type: int32
+            default: 2000
+            min: 500
+            max: 5000
+
+        QDP_STEP_AMP:
+            description:
+                short: Step amplitude
+            type: float
+            default: 0.5
+            min: 0.0
+            max: 1.0
+
+        QDP_ROTATE_AMP:
+            description:
+                short: Leg rotate amplitude
+            type: float
+            default: 0.2
+            min: 0.0
+            max: 1.0


### PR DESCRIPTION
## Summary
- add simple gait logic and parameters to `quadruped`
- document parameters in module.yaml
- document running `Tools/setup/ubuntu.sh` for `make check`
- add rotate amplitude parameter and sinusoidal rotation

## Testing
- `make format`
- `make check_format`
- `make check` *(fails: build interrupted due to environment limits)*


------
https://chatgpt.com/codex/tasks/task_e_68475b780c48832a8707ff488fab5637