### PR TITLE
Enable RC-driven quadruped gait control

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.quadruped_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.quadruped_apps
@@ -1,4 +1,5 @@
 #!/bin/sh
 # Standard apps for a quadruped rover.
 quadruped_gait start
+quadruped_gait_rc start
 land_detector start rover

--- a/src/modules/quadruped_gait/CMakeLists.txt
+++ b/src/modules/quadruped_gait/CMakeLists.txt
@@ -1,10 +1,19 @@
 px4_add_module(
-    MODULE modules__quadruped_gait
-    MAIN quadruped_gait
-    SRCS
-        QuadrupedGait.cpp
-    DEPENDS
-        px4_work_queue
-    MODULE_CONFIG
-        module.yaml
+	MODULE modules__quadruped_gait
+	MAIN quadruped_gait
+	SRCS
+	QuadrupedGait.cpp
+	DEPENDS
+	px4_work_queue
+	MODULE_CONFIG
+	module.yaml
+)
+
+px4_add_module(
+	MODULE modules__quadruped_gait_rc
+	MAIN quadruped_gait_rc
+	SRCS
+	QuadrupedGaitRC.cpp
+	DEPENDS
+	px4_work_queue
 )

--- a/src/modules/quadruped_gait/Kconfig
+++ b/src/modules/quadruped_gait/Kconfig
@@ -1,5 +1,11 @@
 menuconfig MODULES_QUADRUPED_GAIT
-    bool "quadruped_gait"
-    default n
-    ---help---
-        Enable quadruped gait controller
+	bool "quadruped_gait"
+	default n
+	---help---
+		Enable quadruped gait controller
+
+config MODULES_QUADRUPED_GAIT_RC
+	bool "quadruped_gait_rc"
+	default n
+	---help---
+		Publish gait commands from RC inputs

--- a/src/modules/quadruped_gait/QuadrupedGait.cpp
+++ b/src/modules/quadruped_gait/QuadrupedGait.cpp
@@ -36,7 +36,7 @@ using namespace time_literals;
 
 QuadrupedGait::QuadrupedGait() :
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_ctrl)
+       ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl)
 {
 }
 

--- a/src/modules/quadruped_gait/QuadrupedGaitRC.cpp
+++ b/src/modules/quadruped_gait/QuadrupedGaitRC.cpp
@@ -1,0 +1,112 @@
+#include "QuadrupedGaitRC.hpp"
+
+#include <lib/mathlib/mathlib.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/log.h>
+
+QuadrupedGaitRC::QuadrupedGaitRC() :
+	ModuleParams(nullptr),
+       ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl)
+{}
+
+bool QuadrupedGaitRC::init()
+{
+	if (!_manual_control_sub.registerCallback()) {
+		PX4_ERR("callback registration failed");
+		return false;
+	}
+
+	return true;
+}
+
+void QuadrupedGaitRC::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		_manual_control_sub.unregisterCallback();
+		exit_and_cleanup();
+		return;
+	}
+
+	if (_parameter_update_sub.updated()) {
+		parameter_update_s p{};
+		_parameter_update_sub.copy(&p);
+		updateParams();
+	}
+
+	manual_control_setpoint_s mc{};
+
+	if (_manual_control_sub.update(&mc)) {
+		quadruped_gait_command_s cmd{};
+		cmd.timestamp = hrt_absolute_time();
+
+		if (PX4_ISFINITE(mc.aux2)) {
+			cmd.frequency = math::constrain(1.f + mc.aux2, 0.f, 5.f);
+
+		} else {
+			cmd.frequency = NAN;
+		}
+
+		if (PX4_ISFINITE(mc.aux1)) {
+			cmd.amplitude = math::constrain(mc.aux1, 0.f, 1.f);
+
+		} else {
+			cmd.amplitude = NAN;
+		}
+
+		_gait_cmd_pub.publish(cmd);
+	}
+}
+
+int QuadrupedGaitRC::task_spawn(int argc, char *argv[])
+{
+	QuadrupedGaitRC *instance = new QuadrupedGaitRC();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int QuadrupedGaitRC::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int QuadrupedGaitRC::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+Generate quadruped_gait_command from RC inputs. AUX1 controls amplitude and AUX2 controls frequency.
+)DESCR_STR");
+
+    PRINT_MODULE_USAGE_NAME("quadruped_gait_rc", "controller");
+    PRINT_MODULE_USAGE_COMMAND("start");
+    PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+    return 0;
+}
+
+extern "C" __EXPORT int quadruped_gait_rc_main(int argc, char *argv[])
+{
+    return QuadrupedGaitRC::main(argc, argv);
+}
+

--- a/src/modules/quadruped_gait/QuadrupedGaitRC.hpp
+++ b/src/modules/quadruped_gait/QuadrupedGaitRC.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/quadruped_gait_command.h>
+#include <uORB/topics/parameter_update.h>
+
+using namespace time_literals;
+
+class QuadrupedGaitRC : public ModuleBase<QuadrupedGaitRC>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	QuadrupedGaitRC();
+	~QuadrupedGaitRC() override = default;
+
+	static int task_spawn(int argc, char *argv[]);
+	static int custom_command(int argc, char *argv[]);
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	void Run() override;
+
+	uORB::SubscriptionCallbackWorkItem _manual_control_sub{this, ORB_ID(manual_control_setpoint)};
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	uORB::Publication<quadruped_gait_command_s> _gait_cmd_pub{ORB_ID(quadruped_gait_command)};
+};
+


### PR DESCRIPTION
## Summary
- launch new `quadruped_gait_rc` module to translate RC AUX inputs to gait commands
- start the RC module in quadruped init script
- build system updates for new module
- register module in Kconfig
- fix work queue configuration name

## Testing
- `./Tools/astyle/check_code_style.sh src/modules/quadruped_gait/QuadrupedGait.cpp src/modules/quadruped_gait/QuadrupedGaitRC.cpp src/modules/quadruped_gait/CMakeLists.txt src/modules/quadruped_gait/Kconfig ROMFS/px4fmu_common/init.d/rc.quadruped_apps`
- `make px4_sitl_default uorb_headers`
- `make px4_sitl_default modules__quadruped_gait_rc`


------
https://chatgpt.com/codex/tasks/task_e_6847894ba634832a9183bc55c3ea3eac