### PR TITLE
Add quadruped rover simulation

### DIFF
--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -23,6 +23,7 @@ jobs:
         config:
           - {vehicle: "iris",          mission: "MC_mission_box"}
           - {vehicle: "rover",         mission: "rover_mission_1"}
+          - {vehicle: "quadruped_rover", mission: "rover_mission_1"}
 
     steps:
     - uses: actions/checkout@v4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1063_gazebo-classic_quadruped_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1063_gazebo-classic_quadruped_rover
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# @name Quadruped Rover
+# @type Rover
+# @class Rover
+
+. ${R}etc/init.d/rc.rover_differential_defaults
+
+param set-default PWM_MAIN_FUNC1 101
+param set-default PWM_MAIN_FUNC2 101
+param set-default PWM_MAIN_FUNC6 102
+param set-default PWM_MAIN_FUNC7 102

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -61,11 +61,12 @@ px4_add_romfs_files(
 	1042_gazebo-classic_tiltrotor
 	1043_gazebo-classic_standard_vtol_drop
 	1044_gazebo-classic_plane_lidar
-	1045_gazebo-classic_quadtailsitter
-	1060_gazebo-classic_rover
-	1061_gazebo-classic_r1_rover
-	1062_flightgear_tf-r1
-	1070_gazebo-classic_boat
+        1045_gazebo-classic_quadtailsitter
+        1060_gazebo-classic_rover
+        1061_gazebo-classic_r1_rover
+        1062_flightgear_tf-r1
+        1063_gazebo-classic_quadruped_rover
+        1070_gazebo-classic_boat
 
 	2507_gazebo-classic_cloudship
 

--- a/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
+++ b/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
@@ -20,7 +20,7 @@ function spawn_model() {
 	X=${X:=0.0}
 	Y=${Y:=$((3*${N}))}
 
-	SUPPORTED_MODELS=("iris" "plane" "standard_vtol" "rover" "r1_rover" "typhoon_h480")
+       SUPPORTED_MODELS=("iris" "plane" "standard_vtol" "rover" "r1_rover" "quadruped_rover" "typhoon_h480")
 	if [[ " ${SUPPORTED_MODELS[*]} " != *"$MODEL"* ]];
 	then
 		echo "ERROR: Currently only vehicle model $MODEL is not supported!"

--- a/docs/en/sim_gazebo_classic/index.md
+++ b/docs/en/sim_gazebo_classic/index.md
@@ -82,6 +82,7 @@ For the full list of build targets run `make px4_sitl list_vmd_make_targets` (an
 | [Tailsitter VTOL](../sim_gazebo_classic/vehicles.md#tailsitter-vtol)                                                               | `make px4_sitl gazebo-classic_tailsitter`                 |
 | [Ackerman UGV (Rover)](../sim_gazebo_classic/vehicles.md#ackermann-ugv)                                                            | `make px4_sitl gazebo-classic_rover`                      |
 | [Differential UGV (Rover)](../sim_gazebo_classic/vehicles.md#differential-ugv)                                                     | `make px4_sitl gazebo-classic_r1_rover`                   |
+| [Quadruped Rover](../sim_gazebo_classic/vehicles.md#quadruped-rover)                                                     | `make px4_sitl gazebo-classic_quadruped_rover` |
 | [HippoCampus TUHH (UUV: Unmanned Underwater Vehicle)](../sim_gazebo_classic/vehicles.md#unmanned-underwater-vehicle-uuv-submarine) | `make px4_sitl gazebo-classic_uuv_hippocampus`            |
 | [Boat (USV: Unmanned Surface Vehicle)](../sim_gazebo_classic/vehicles.md#hippocampus-tuhh-uuv)                                     | `make px4_sitl gazebo-classic_boat`                       |
 | [Cloudship (Airship)](../sim_gazebo_classic/vehicles.md#airship)                                                                   | `make px4_sitl gazebo-classic_cloudship`                  |

--- a/docs/en/sim_gazebo_classic/vehicles.md
+++ b/docs/en/sim_gazebo_classic/vehicles.md
@@ -118,6 +118,14 @@ make px4_sitl gazebo-classic_r1_rover
 
 ![Rover in Gazebo Classic](../../assets/simulation/gazebo_classic/vehicles/r1_rover.png)
 
+### Quadruped Rover
+
+```sh
+make px4_sitl gazebo-classic_quadruped_rover
+```
+
+The quadruped rover model is a simple extension of the differential rover using the same controller.
+
 ## Unmanned Underwater Vehicle (UUV/Submarine)
 
 ### HippoCampus TUHH UUV

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -92,9 +92,10 @@ if(gazebo_FOUND)
 		plane_catapult
 		plane_lidar
 		px4vision
-		quadtailsitter
-		r1_rover
-		rover
+                quadtailsitter
+                r1_rover
+                quadruped_rover
+                rover
 		standard_vtol
 		standard_vtol_drop
 		tailsitter


### PR DESCRIPTION
## Summary
- add quadruped rover airframe script
- update airframe list and SITL targets
- support the model in multi-vehicle runs
- document quadruped rover in Gazebo Classic docs
- run quadruped rover in MAVROS mission tests

## Testing
- `make px4_sitl_default -j4` *(fails: ModuleNotFoundError: No module named 'genmsg')*

------
https://chatgpt.com/codex/tasks/task_e_684b7346a698832aae53f13345244f23