### PR TITLE
Fix parameter update subscription

### DIFF
--- a/src/modules/quadruped_gait/QuadrupedGait.cpp
+++ b/src/modules/quadruped_gait/QuadrupedGait.cpp
@@ -32,8 +32,6 @@
  ****************************************************************************/
 
 #include "QuadrupedGait.hpp"
-// Include interval-based subscription wrapper to throttle parameter updates
-#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
 
 using namespace time_literals;

--- a/src/modules/quadruped_gait/QuadrupedGait.hpp
+++ b/src/modules/quadruped_gait/QuadrupedGait.hpp
@@ -40,7 +40,6 @@
 
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/quadruped_leg_command.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/quadruped_gait_command.h>
@@ -65,7 +64,7 @@ private:
 
        uORB::Subscription _gait_cmd_sub{ORB_ID(quadruped_gait_command)};
        uORB::Subscription _leg_cmd_sub{ORB_ID(quadruped_leg_command)};
-       uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+   uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 	float _phase{0.f};
 	float _freq{1.f};


### PR DESCRIPTION
## Summary
- adjust parameter update subscription for quadruped gait module
- remove stale interval headers

## Testing
- `make px4_sitl_default none -j2` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684e8e9f9398832a9e4d5a3350f80046