### PR TITLE
Add quadruped gazebo model and docs

### DIFF
--- a/Tools/simulation/models/quadruped/model.config
+++ b/Tools/simulation/models/quadruped/model.config
@@ -1,0 +1,11 @@
+<?xml version='1.0'?>
+<model>
+  <name>quadruped</name>
+  <version>1.0</version>
+  <sdf version='1.9'>model.sdf</sdf>
+  <author>
+    <name>PX4</name>
+    <email>dev@px4.io</email>
+  </author>
+  <description>Simple placeholder quadruped model for simulation.</description>
+</model>

--- a/Tools/simulation/models/quadruped/model.sdf
+++ b/Tools/simulation/models/quadruped/model.sdf
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sdf version='1.9'>
+  <model name='quadruped'>
+    <link name='base_link'>
+      <pose>0 0 0.2 0 0 0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <inertia>
+          <ixx>0.01</ixx>
+          <iyy>0.01</iyy>
+          <izz>0.01</izz>
+        </inertia>
+      </inertial>
+      <collision name='collision'>
+        <geometry>
+          <box><size>0.4 0.2 0.1</size></box>
+        </geometry>
+      </collision>
+      <visual name='visual'>
+        <geometry>
+          <box><size>0.4 0.2 0.1</size></box>
+        </geometry>
+      </visual>
+    </link>
+    <!-- simple legs for visual reference -->
+    <link name='leg_fl'>
+      <pose>0.15 0.1 0 0 0 0</pose>
+    </link>
+    <link name='leg_fr'>
+      <pose>0.15 -0.1 0 0 0 0</pose>
+    </link>
+    <link name='leg_rl'>
+      <pose>-0.15 0.1 0 0 0 0</pose>
+    </link>
+    <link name='leg_rr'>
+      <pose>-0.15 -0.1 0 0 0 0</pose>
+    </link>
+  </model>
+</sdf>

--- a/docs/en/frames_rover/quadruped.md
+++ b/docs/en/frames_rover/quadruped.md
@@ -7,4 +7,12 @@ Turn Motor (TM) and Spin Motor (SM) provide rover-style driving, while Rotate Mo
 
 Simulation of the quadruped rover is supported with Gazebo using the `gz_quadruped` target. See [Simulation > Gazebo](../sim_gazebo_gz/vehicles.md#quadruped-rover) for details.
 
+::: tip
+If the build or simulation fails with an error that the `quadruped` model cannot be found, the submodule containing the Gazebo models may not have been initialized. Fetch the models using:
+
+```sh
+git submodule update --init --recursive Tools/simulation/gz
+```
+:::
+
 See [Configuration/Tuning](../config_rover/quadruped.md) to set up your rover and [Drive Modes](../flight_modes_rover/quadruped.md) for the supported drive modes.

--- a/src/modules/quadruped/Quadruped.cpp
+++ b/src/modules/quadruped/Quadruped.cpp
@@ -21,7 +21,16 @@ public:
 		_start_time = hrt_absolute_time();
 	}
 
-	~Quadruped() override { }
+        ~Quadruped() override { }
+
+       /** @see ModuleBase */
+       static int task_spawn(int argc, char *argv[]);
+
+       /** @see ModuleBase */
+       static int custom_command(int argc, char *argv[]);
+
+       /** @see ModuleBase */
+       static int print_usage(const char *reason = nullptr);
 
 	bool init()
 	{
@@ -101,6 +110,53 @@ private:
                 (ParamFloat<px4::params::QDP_MAX_SPEED>) _param_qdp_max_speed
         )
 };
+
+int Quadruped::task_spawn(int argc, char *argv[])
+{
+       Quadruped *instance = new Quadruped();
+
+       if (instance) {
+               _object.store(instance);
+               _task_id = task_id_is_work_queue;
+
+               if (instance->init()) {
+                       return PX4_OK;
+               }
+
+       } else {
+               PX4_ERR("alloc failed");
+       }
+
+       delete instance;
+       _object.store(nullptr);
+       _task_id = -1;
+
+       return PX4_ERROR;
+}
+
+int Quadruped::custom_command(int argc, char *argv[])
+{
+       return print_usage("unknown command");
+}
+
+int Quadruped::print_usage(const char *reason)
+{
+       if (reason) {
+               PX4_WARN("%s\n", reason);
+       }
+
+       PRINT_MODULE_DESCRIPTION(
+               R"DESCR_STR(
+### Description
+Simple quadruped gait controller. Maps rover drive commands to leg actuators.
+)DESCR_STR");
+
+       PRINT_MODULE_USAGE_NAME("quadruped", "controller");
+       PRINT_MODULE_USAGE_COMMAND("start");
+       PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+       return 0;
+}
 
 int Quadruped_main(int argc, char *argv[])
 {

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -12,10 +12,11 @@
 # -----------------------------------------------------------------------
 
 export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models
+export PX4_GZ_MODELS_EXTRA=@PX4_SOURCE_DIR@/Tools/simulation/models
 export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds
 export PX4_GZ_PLUGINS=@PX4_BINARY_DIR@/src/modules/simulation/gz_plugins
 export PX4_GZ_SERVER_CONFIG=@PX4_SOURCE_DIR@/src/modules/simulation/gz_bridge/server.config
 
-export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:$PX4_GZ_MODELS:$PX4_GZ_WORLDS
+export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:$PX4_GZ_MODELS:$PX4_GZ_WORLDS:$PX4_GZ_MODELS_EXTRA
 export GZ_SIM_SYSTEM_PLUGIN_PATH=$GZ_SIM_SYSTEM_PLUGIN_PATH:$PX4_GZ_PLUGINS
 export GZ_SIM_SERVER_CONFIG_PATH=$PX4_GZ_SERVER_CONFIG


### PR DESCRIPTION
## Summary
- add PX4_GZ_MODELS_EXTRA to include user models
- add simple quadruped placeholder model
- document submodule update step for quadruped rover
- implement missing ModuleBase hooks for quadruped module

## Testing
- `make px4_sitl gz_quadruped` *(fails: unknown target 'gz_quadruped')*


------
https://chatgpt.com/codex/tasks/task_e_684ebad8ddc0832a8a71da3312182dfd