### PR TITLE
Fix quadruped module and doc dependency note

### DIFF
--- a/docs/en/sim_gazebo_gz/vehicles.md
+++ b/docs/en/sim_gazebo_gz/vehicles.md
@@ -210,3 +210,9 @@ make px4_sitl gz_quadruped
 
 > **Note** The `kconfiglib` Python package is required for this build. Install it using `Tools/setup/ubuntu.sh` or `pip3 install kconfiglib` if missing.
 
+> **Note** If the build fails with `ModuleNotFoundError` (e.g. for the `em` or `genmsg` modules), install the PX4 Python dependencies using:
+>
+> ```sh
+> pip3 install -r Tools/setup/requirements.txt
+> ```
+

--- a/src/modules/quadruped/Quadruped.cpp
+++ b/src/modules/quadruped/Quadruped.cpp
@@ -21,7 +21,16 @@ public:
 		_start_time = hrt_absolute_time();
 	}
 
-	~Quadruped() override { }
+        ~Quadruped() override { }
+
+       /** @see ModuleBase */
+       static int task_spawn(int argc, char *argv[]);
+
+       /** @see ModuleBase */
+       static int custom_command(int argc, char *argv[]);
+
+       /** @see ModuleBase */
+       static int print_usage(const char *reason = nullptr);
 
 	bool init()
 	{
@@ -102,7 +111,50 @@ private:
         )
 };
 
-int Quadruped_main(int argc, char *argv[])
-{
-	return Quadruped::main(argc, argv);
+int Quadruped::task_spawn(int argc, char *argv[]) {
+  Quadruped *instance = new Quadruped();
+
+  if (instance) {
+    _object.store(instance);
+    _task_id = task_id_is_work_queue;
+
+    if (instance->init()) {
+      return PX4_OK;
+    }
+
+  } else {
+    PX4_ERR("alloc failed");
+  }
+
+  delete instance;
+  _object.store(nullptr);
+  _task_id = -1;
+
+  return PX4_ERROR;
+}
+
+int Quadruped::custom_command(int argc, char *argv[]) {
+  return print_usage("unknown command");
+}
+
+int Quadruped::print_usage(const char *reason) {
+  if (reason) {
+    PX4_WARN("%s\n", reason);
+  }
+
+  PRINT_MODULE_DESCRIPTION(
+      R"DESCR_STR(
+### Description
+Quadruped rover control module mapping throttle, steering and velocity setpoints to leg commands.
+)DESCR_STR");
+
+  PRINT_MODULE_USAGE_NAME("quadruped", "controller");
+  PRINT_MODULE_USAGE_COMMAND("start");
+  PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+  return 0;
+}
+
+extern "C" __EXPORT int quadruped_main(int argc, char *argv[]) {
+  return Quadruped::main(argc, argv);
 }


### PR DESCRIPTION
## Summary
- declare ModuleBase methods in quadruped controller
- document Python dependencies required for Gazebo quadruped build

## Testing
- `make px4_sitl` *(succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_684f72120cd8832a81cd099168d0d516