### PR TITLE
Fix quadruped Gazebo model sensors

### DIFF
--- a/Tools/simulation/models/quadruped/model.sdf
+++ b/Tools/simulation/models/quadruped/model.sdf
@@ -21,6 +21,102 @@
           <box><size>0.4 0.2 0.1</size></box>
         </geometry>
       </visual>
+      <!-- basic sensors for SITL -->
+      <sensor name='imu_sensor' type='imu'>
+        <always_on>1</always_on>
+        <update_rate>250</update_rate>
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type='gaussian'>
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
+      </sensor>
+      <sensor name='air_pressure_sensor' type='air_pressure'>
+        <always_on>1</always_on>
+        <update_rate>50</update_rate>
+        <air_pressure>
+          <pressure>
+            <noise type='gaussian'>
+              <mean>0</mean>
+              <stddev>0.01</stddev>
+            </noise>
+          </pressure>
+        </air_pressure>
+      </sensor>
+      <sensor name='magnetometer_sensor' type='magnetometer'>
+        <always_on>1</always_on>
+        <update_rate>100</update_rate>
+        <magnetometer>
+          <x>
+            <noise type='gaussian'>
+              <stddev>0.0001</stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type='gaussian'>
+              <stddev>0.0001</stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type='gaussian'>
+              <stddev>0.0001</stddev>
+            </noise>
+          </z>
+        </magnetometer>
+      </sensor>
+      <sensor name='navsat_sensor' type='navsat'>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+      </sensor>
     </link>
     <!-- simple legs for visual reference -->
     <link name='leg_fl'>


### PR DESCRIPTION
## Summary
- add IMU, barometer, magnetometer and GPS sensors to the quadruped model

## Testing
- `make px4_sitl_default check` *(fails: `mavgen.py` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68529861e418832aa91edda1c7086214