### PR TITLE
Add note about NodeShared error in ROS2 guide

### DIFF
--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -176,6 +176,13 @@ You can leave the agent running in this terminal!
 Note that only one agent is allowed per connection channel.
 :::
 
+::: tip
+If you forget to start the agent, PX4 will repeatedly print
+`NodeShared::Publish() Error: Interrupted system call` when it tries to
+send messages. Simply start the agent (as shown above) or disable the
+`uxrce_dds_client` in your startup script to remove the warning.
+:::
+
 #### Start the Client
 
 The PX4 simulator starts the uXRCE-DDS client automatically, connecting to UDP port 8888 on the local host.


### PR DESCRIPTION
## Summary
- document how failing to run MicroXRCEAgent causes `NodeShared::Publish()` errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852b1a5a3cc832aa3a85027e73a28b2