### PR TITLE
Add instructions for restarting XRCE-DDS agent

### DIFF
--- a/docs/en/ros2/user_guide.md
+++ b/docs/en/ros2/user_guide.md
@@ -176,6 +176,19 @@ You can leave the agent running in this terminal!
 Note that only one agent is allowed per connection channel.
 :::
 
+::: tip
+If you forget to start the agent, PX4 will repeatedly print
+`NodeShared::Publish() Error: Interrupted system call` when it tries to
+send messages. Start the agent again using:
+
+```sh
+MicroXRCEAgent udp4 -p 8888
+```
+
+Alternatively disable the `uxrce_dds_client` in your startup script to
+remove the warning.
+:::
+
 #### Start the Client
 
 The PX4 simulator starts the uXRCE-DDS client automatically, connecting to UDP port 8888 on the local host.


### PR DESCRIPTION
## Summary
- document how to start MicroXRCEAgent in ROS2 user guide when encountering `NodeShared::Publish()` errors

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852b1a5a3cc832aa3a85027e73a28b2