### PR TITLE
Add quadruped Gazebo world

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4022_gz_quadruped
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4022_gz_quadruped
@@ -6,7 +6,7 @@
 . ${R}etc/init.d/rc.quadruped_defaults
 
 PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=rover}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=quadruped}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=quadruped}
 
 param set-default SIM_GZ_EN 1 # Gazebo bridge

--- a/Tools/simulation/worlds/quadruped.sdf
+++ b/Tools/simulation/worlds/quadruped.sdf
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version="1.9">
+  <world name="quadruped">
+    <physics type="ode">
+      <max_step_size>0.002</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>500</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type="adiabatic"/>
+    <scene>
+      <grid>true</grid>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>true</shadows>
+    </scene>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <bounce/>
+            <contact>
+              <collide_bitmask>65535</collide_bitmask>
+              <ode>
+                <min_depth>0.005</min_depth>
+                <kp>1e8</kp>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <cast_shadows>false</cast_shadows>
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>400 400</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+        <pose>0 0 0 0 -0 0</pose>
+        <inertial>
+          <pose>0 0 0 0 -0 0</pose>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+        <enable_wind>false</enable_wind>
+      </link>
+      <pose>0 0 0 0 -0 0</pose>
+      <self_collide>false</self_collide>
+    </model>
+    <light name="sunUTC" type="directional">
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>true</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+      <spot>
+        <inner_angle>0</inner_angle>
+        <outer_angle>0</outer_angle>
+        <falloff>0</falloff>
+      </spot>
+    </light>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>47.397971057728974</latitude_deg>
+      <longitude_deg> 8.546163739800146</longitude_deg>
+      <elevation>0</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>

--- a/docs/en/sim_gazebo_gz/vehicles.md
+++ b/docs/en/sim_gazebo_gz/vehicles.md
@@ -202,7 +202,7 @@ make px4_sitl gz_rover_ackermann
 
 ### Quadruped Rover
 
-[Quadruped Rover](../frames_rover/quadruped.md) uses the [rover world](../sim_gazebo_gz/worlds.md#rover) by default and is based on the existing rover model. It drives four motors per leg (TM, SM, RM and PM).
+[Quadruped Rover](../frames_rover/quadruped.md) uses the [quadruped world](../sim_gazebo_gz/worlds.md#quadruped) by default and is based on the existing rover model. It drives four motors per leg (TM, SM, RM and PM).
 
 ```sh
 make px4_sitl gz_quadruped

--- a/docs/en/sim_gazebo_gz/worlds.md
+++ b/docs/en/sim_gazebo_gz/worlds.md
@@ -59,6 +59,12 @@ Rover world is very similar to [lawn world](#lawn), but with these tow main diff
 
 :::
 
+## Quadruped {#quadruped}
+
+World tailored for the quadruped rover. It is based on the rover world configuration.
+
+[PX4-gazebo-models/main/worlds/quadruped.sdf](https://github.com/PX4/PX4-gazebo-models/blob/main/worlds/quadruped.sdf)
+
 ## Walls
 
 World with walls that is designed for testing [collision prevention](../computer_vision/collision_prevention.md).

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -13,7 +13,7 @@
 
 export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models
 export PX4_GZ_MODELS_EXTRA=@PX4_SOURCE_DIR@/Tools/simulation/models
-export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds
+export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds:@PX4_SOURCE_DIR@/Tools/simulation/worlds
 export PX4_GZ_PLUGINS=@PX4_BINARY_DIR@/src/modules/simulation/gz_plugins
 export PX4_GZ_SERVER_CONFIG=@PX4_SOURCE_DIR@/src/modules/simulation/gz_bridge/server.config
 


### PR DESCRIPTION
## Summary
- add a quadruped world for Gazebo
- point quadruped airframe to the new world
- load PX4's local worlds directory in gz_env
- document the quadruped world and update vehicle docs

## Testing
- `make px4_sitl` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6853ae72a478832a96399a78e70c2bf0