### PR TITLE
Fix gz world path handling

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -45,9 +45,15 @@ if [ -z "${PX4_GZ_STANDALONE}" ]; then
 			. ../gz_env.sh
 		fi
 
-		echo "INFO  [init] Starting gazebo with world: ${PX4_GZ_WORLDS}/${PX4_GZ_WORLD}.sdf"
+                # PX4_GZ_WORLDS may contain multiple directories separated by ':'
+                # Only the first entry should be used when specifying the world
+                IFS=':' read -r px4_worlds_first _ <<EOF
+${PX4_GZ_WORLDS}
+EOF
 
-		${gz_command} ${gz_sub_command} --verbose=${GZ_VERBOSE:=1} -r -s "${PX4_GZ_WORLDS}/${PX4_GZ_WORLD}.sdf" &
+                echo "INFO  [init] Starting gazebo with world: ${px4_worlds_first}/${PX4_GZ_WORLD}.sdf"
+
+                ${gz_command} ${gz_sub_command} --verbose=${GZ_VERBOSE:=1} -r -s "${px4_worlds_first}/${PX4_GZ_WORLD}.sdf" &
 
 		if [ -z "${HEADLESS}" ]; then
 			echo "INFO  [init] Starting gz gui"


### PR DESCRIPTION
## Summary
- handle multi-path PX4_GZ_WORLDS to avoid invalid world URI

## Testing
- `./Tools/astyle/check_code_style.sh ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim` *(fails: astyle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4525e04832abd0ff73d4056805a