### PR TITLE
Fix gz world path handling

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim
@@ -45,9 +45,24 @@ if [ -z "${PX4_GZ_STANDALONE}" ]; then
 			. ../gz_env.sh
 		fi
 
-		echo "INFO  [init] Starting gazebo with world: ${PX4_GZ_WORLDS}/${PX4_GZ_WORLD}.sdf"
+               # PX4_GZ_WORLDS may contain multiple directories separated by ':'
+               # Select the first directory that actually contains the world file
+               IFS=':'
+               for d in ${PX4_GZ_WORLDS}; do
+                       if [ -f "${d}/${PX4_GZ_WORLD}.sdf" ]; then
+                               px4_world_dir="$d"
+                               break
+                       fi
+               done
+               IFS=' \t\n'
 
-		${gz_command} ${gz_sub_command} --verbose=${GZ_VERBOSE:=1} -r -s "${PX4_GZ_WORLDS}/${PX4_GZ_WORLD}.sdf" &
+               if [ -z "${px4_world_dir}" ]; then
+                       px4_world_dir="${PX4_GZ_WORLDS%%:*}"
+               fi
+
+               echo "INFO  [init] Starting gazebo with world: ${px4_world_dir}/${PX4_GZ_WORLD}.sdf"
+
+               ${gz_command} ${gz_sub_command} --verbose=${GZ_VERBOSE:=1} -r -s "${px4_world_dir}/${PX4_GZ_WORLD}.sdf" &
 
 		if [ -z "${HEADLESS}" ]; then
 			echo "INFO  [init] Starting gz gui"


### PR DESCRIPTION
## Summary
- handle multi-path PX4_GZ_WORLDS by selecting the directory containing the world file

## Testing
- `./Tools/astyle/check_code_style.sh ROMFS/px4fmu_common/init.d-posix/px4-rc.gzsim` *(fails: formatting issue found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4525e04832abd0ff73d4056805a